### PR TITLE
Fix /api/events/upcoming resolving without response

### DIFF
--- a/pages/api/events/upcoming.js
+++ b/pages/api/events/upcoming.js
@@ -1,10 +1,11 @@
 import { fetchGroupedEvents } from "../../../services/tkoalyEventService";
 
-export default function handle(req, res) {
-  fetchGroupedEvents()
-    .then(events => res.json(events))
-    .catch((e) => {
-      console.log(e)
-      res.status(500).json({ error: "Internal server error" });
-    });
+export default async function handle(_req, res) {
+  try {
+    const events = await fetchGroupedEvents();
+    return res.json(events);
+  } catch (e) {
+    console.log(e);
+    res.status(500).json({ error: "Internal server error" });
+  }
 }


### PR DESCRIPTION
Gets rid of "API resolved without sending a response for /api/events/upcoming, this may result in stalled requests." messages.