### PR TITLE
Specify weekly filter

### DIFF
--- a/src/server/TKOalyEvents.ts
+++ b/src/server/TKOalyEvents.ts
@@ -81,7 +81,8 @@ const getUpcomingEvents = async () =>
 const separateWeeklyAndMeetings = (events: TKOalyEvent[]) => {
 	const Weekly: TKOalyEvent[] = [];
 	const rest = events.filter((event) => {
-		if (/weekly|club\b|kerho\b|vuoro\b/i.test(event.name)) {
+	 	// TODO: Have this not be manual. The best solution would be for the backend to support weekly events natively.
+		if (/weekly|chess club\b|shakkikerho\b|liikuntavuoro\b/i.test(event.name)) {
 			if (
 				!Weekly.some(
 					(e) =>


### PR DESCRIPTION
The weekly filter caught some events that are not weekly. For now, this needs to be quite specific until the backend supports marking events as weekly.