### PR TITLE
docs: clarify the documentation around .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# https://digitransit.fi/en/developers/api-registration/
+DIGITRANSIT_TOKEN=

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ npm install
 npm run dev
 ```
 
+To set up the correct environment variables, rename `.env.example` to `.env` and fill in your `DIGITRANSIT_TOKEN`. You can obtain a token by following [this guide](https://digitransit.fi/en/developers/api-registration/).
+
 ## Project structure
 
 Slides are defined as parallel routes in [`src/app/(infoscreen)/layout.tsx`](<src/app/(infoscreen)/layout.tsx>)


### PR DESCRIPTION
Without proper environment variable documentation it can be hard for new contributors to get the project fully running locally.